### PR TITLE
Multithreading the make calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN \
 	--disable-debug \
 	--enable-encryption \
 	--prefix=/usr && \
- make && \
+ make -j4 && \
  make DESTDIR=/tmp/rasterbar-build install && \
  strip --strip-unneeded \
 	/tmp/rasterbar-build/usr/lib/libtorrent-rasterbar.so* \
@@ -54,7 +54,7 @@ RUN \
  ./configure \
 	--disable-gui \
 	--prefix=/usr && \
- make && \
+ make -j4 && \
  make INSTALL_ROOT=/tmp/qbittorrent-build install
 
 ############## runtime stage ##############


### PR DESCRIPTION
Adding the flag -j4 to all the make steps to use up to 4 threads to compile which could multiply by up to 4x the speed of compilation. 
(could be more but not every one have more than 4 core and if it's too big in regards of the number of core this could have a negative impact on the performance)