### PR TITLE
Add HEALTHCHECK to image with API endoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,6 @@ COPY root/ /
 # ports and volumes
 EXPOSE 6881 6881/udp 8080
 VOLUME /config /downloads
+
+HEALTHCHECK --interval=10s --timeout=10s --start-period=20s \
+  CMD curl --fail http://127.0.0.1:8080/api/v2/app/version || exit 1


### PR DESCRIPTION

## Description:

I've added a docker command line healthcheck that uses the api endpoint for bittorrent. I got the idea and the copy paste from @crazy-max. Anyway I thought it better to create a pull request. I don't want to maintain a fork when I'm sure others would enjoy this too.

## Benefits of this PR and context:
In a docker environment that already leverages healthchecks this would be an awesome feature. In my case I use traffic as my edge router and it watches a containers health status and connects or disconnects that router depending. Healthcheck status could also be used to monitor and auto restart the container

## How Has This Been Tested?
I built and ran the image on my Manjaro Linux desktop running kernel 5.3.11 and Docker 
Docker version 19.03.5, build 633a0ea838 with Docker Compose 1.25.0, build 0a186604 without issue.


## Source / References:
https://github.com/crazy-max/docker-qbittorrent
