### PR TITLE
Drop Python 2 support, removed in qBittorrent v4.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN \
  apt-get update && \
  apt-get install -y \
 	gnupg \
-	python \
 	python3 && \
  curl -s https://bintray.com/user/downloadSubjectPublicKey?username=fedarovich | apt-key add - && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:11371 --recv-keys 7CA69FC4 && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -19,7 +19,6 @@ RUN \
  apt-get update && \
  apt-get install -y \
 	gnupg \
-	python \
 	python3 && \
  curl -s https://bintray.com/user/downloadSubjectPublicKey?username=fedarovich | apt-key add - && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:11371 --recv-keys 7CA69FC4 && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -19,7 +19,6 @@ RUN \
  apt-get update && \
  apt-get install -y \
 	gnupg \
-	python \
 	python3 && \
  curl -s https://bintray.com/user/downloadSubjectPublicKey?username=fedarovich | apt-key add - && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:11371 --recv-keys 7CA69FC4 && \

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **26.05.20:** - Drop Python 2 support, removed in qBittorrent v4.2.2
 * **03.04.20:** - Fix adding search engine plugin
 * **02.08.19:** - Add qbitorrent-cli for processing scripts.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

## Description:
Drop Python 2 support, removed in qBittorrent v4.2.2

I'm qBittorrent developer. We dropped Python 2 support a couple of months ago, it's time to clean up the Docker image.

## Benefits of this PR and context:
Resolves #67
Reduces Docker image in 22 MB.

## How Has This Been Tested?
Yes. Local build and test.

## Source / References:
https://github.com/qbittorrent/search-plugins/issues/84#issuecomment-619539387