### PR TITLE
Fix issue #70. Search in web UI is broken due to python3 issue. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN \
  apt-get install -y \
 	gnupg \
 	python3 && \
+	update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
  curl -s https://bintray.com/user/downloadSubjectPublicKey?username=fedarovich | apt-key add - && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:11371 --recv-keys 7CA69FC4 && \
  echo "deb http://ppa.launchpad.net/qbittorrent-team/qbittorrent-stable/ubuntu bionic main" >> /etc/apt/sources.list.d/qbitorrent.list && \


### PR DESCRIPTION
In linuxserver/qbittorrent:latest as of 2020-06-11, the search feature of web-ui is broken. Examining docker logs for a clue, I saw the error:

Could not parse Nova search engine capabilities, msg:  
Error:  Traceback (most recent call last):
  File "/config/data/qBittorrent/nova3/nova2.py", line 36, in <module>
    import urllib.parse
ImportError: No module named parse

When I bash into the container and run python --version it says python 2. My change makes python 3 the default python binary to use. 