### PR TITLE
30-config: Stop creating /config/data directory on startup

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -69,6 +69,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "12.11.20:", desc: "Stop creating /config/data directory on startup" }
   - { date: "03.04.20:", desc: "Fix adding search engine plugin" }
   - { date: "02.08.19:", desc: "Add qbitorrent-cli for processing scripts." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,9 +1,7 @@
 #!/usr/bin/with-contenv bash
 
-# make our folders
-mkdir -p \
-	/config/qBittorrent \
-	/config/data
+# make our folder
+mkdir -p /config/qBittorrent
 
 # copy config
 [[ ! -e /config/qBittorrent/qBittorrent.conf ]] && \


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-qbittorrent/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description:
The `/config/data`directory was deprecated in qBittorrent v4.3.0, so there is no reason to create it at startup anymore.

## Benefits of this PR and context:
This pull request fixes #85.

## How Has This Been Tested?
This change does not affect existing installations of qBittorrent. It will only affect new installations of qBittorrent, where the `/config/data` directory is not used to begin with.