### PR TITLE
Safer BT_backup migration

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -9,7 +9,10 @@ mkdir -p /config/qBittorrent
 
 # v4.3.3 BT_backup migration
 [[ -d /config/data/qBittorrent/BT_backup/ ]] && \
-	cp -a /config/data/qBittorrent/BT_backup/.  /config/qBittorrent/BT_backup/
+	mv /config/qBittorrent/BT_backup/ /config/qBittorrent/BT_backup.bak/ && \
+	mkdir /config/qBittorrent/BT_backup/ && \
+	cp -a /config/data/qBittorrent/BT_backup/.  /config/qBittorrent/BT_backup/ && \
+	mv /config/data/qBittorrent/BT_backup/ /config/data/qBittorrent/BT_backup.old/
 
 # chown download directory if currently not set to abc
 if [[ "$(stat -c '%U' /downloads)" != "abc" ]]; then


### PR DESCRIPTION
Backup /config/qBittorrent/BT_backup/ before we copy anything
Rename /config/data/qBittorrent/BT_backup/ after copy so we don't do it again.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-qbittorrent/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Make the BT_backup migration safer; backup existing folder before we copy anything and then rename the source folder once we've done the copy so we don't attempt it again.

## Benefits of this PR and context:
Minimise risk of data loss.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
