### PR TITLE
build unrar add 7zip and use qbt bins for alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,39 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thespad"
 
 # environment settings
+ARG QBT_VERSION=1.7
+ARG UNRAR_VERSION=6.1.4
 ENV HOME="/config" \
 XDG_CONFIG_HOME="/config" \
 XDG_DATA_HOME="/config"
 
 # install runtime packages and qbitorrent-cli
 RUN \
+  echo "**** install build packages ****" && \
+  apk add --no-cache --upgrade --virtual=build-dependencies \
+    make \
+    g++ \
+    gcc && \
+  echo "**** install packages ****" && \
   apk add -U --update --no-cache \
     bash \
     curl \
+    icu-libs \
+    libstdc++ \
+    openssl \
+    p7zip \
     python3 && \
+  echo "**** install unrar from source ****" && \
+  mkdir /tmp/unrar && \
+  curl -o \
+    /tmp/unrar.tar.gz -L \
+    "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/unrar.tar.gz -C \
+    /tmp/unrar --strip-components=1 && \
+  cd /tmp/unrar && \
+  make && \
+  install -v -m755 unrar /usr/bin && \
   if [ -z ${QBITTORRENT_VERSION+x} ]; then \
     QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
     && awk '/^P:qbittorrent-nox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
@@ -26,19 +49,15 @@ RUN \
   apk add -U --upgrade --no-cache \
     qbittorrent-nox==${QBITTORRENT_VERSION} && \
   echo "***** install qbitorrent-cli ****" && \
-  if [ -z ${QBT_VERSION+x} ]; then \
-    QBT_VERSION=$(curl -sX GET "https://api.github.com/repos/ludviglundgren/qbittorrent-cli/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
-  fi && \
-  curl -o \
-    /tmp/qbt.tar.gz -L \
-    "https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${QBT_VERSION}/qbittorrent-cli_$(echo $QBT_VERSION | cut -c2-)_linux_amd64.tar.gz" && \
-  tar xzf \
-    /tmp/qbt.tar.gz -C \
-    /tmp && \
-    mv /tmp/qbt /usr/bin && \
+  curl -L \
+    -o /usr/bin/qbt \
+    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt" && \
+  chmod +x /usr/bin/qbt && \
   echo "**** cleanup ****" && \
+  apk del --purge \
+    build-dependencies && \
   rm -rf \
+    /root/.cache \
     /tmp/*
 
 # add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,13 @@ RUN \
   apk add -U --upgrade --no-cache \
     qbittorrent-nox==${QBITTORRENT_VERSION} && \
   echo "***** install qbitorrent-cli ****" && \
+  mkdir /qbt && \
   curl -L \
-    -o /usr/bin/qbt \
-    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt" && \
-  chmod +x /usr/bin/qbt && \
+    -o /tmp/qbt.tar.gz \
+    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt.tar.gz" && \
+  tar xf \
+    /tmp/qbt.tar.gz -C \
+    /qbt && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -9,36 +9,55 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thespad"
 
 # environment settings
+ARG QBT_VERSION=1.7
+ARG UNRAR_VERSION=6.1.4
 ENV HOME="/config" \
 XDG_CONFIG_HOME="/config" \
 XDG_DATA_HOME="/config"
 
 # install runtime packages and qbitorrent-cli
 RUN \
+  echo "**** install build packages ****" && \
+  apk add --no-cache --upgrade --virtual=build-dependencies \
+    make \
+    g++ \
+    gcc && \
+  echo "**** install packages ****" && \
   apk add -U --update --no-cache \
     bash \
     curl \
+    icu-libs \
+    libstdc++ \
+    openssl \
+    p7zip \
     python3 && \
+  echo "**** install unrar from source ****" && \
+  mkdir /tmp/unrar && \
+  curl -o \
+    /tmp/unrar.tar.gz -L \
+    "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/unrar.tar.gz -C \
+    /tmp/unrar --strip-components=1 && \
+  cd /tmp/unrar && \
+  make && \
+  install -v -m755 unrar /usr/bin && \
   if [ -z ${QBITTORRENT_VERSION+x} ]; then \
-    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
     && awk '/^P:qbittorrent-nox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
   fi && \
   apk add -U --upgrade --no-cache \
     qbittorrent-nox==${QBITTORRENT_VERSION} && \
   echo "***** install qbitorrent-cli ****" && \
-  if [ -z ${QBT_VERSION+x} ]; then \
-    QBT_VERSION=$(curl -sX GET "https://api.github.com/repos/ludviglundgren/qbittorrent-cli/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
-  fi && \
-  curl -o \
-    /tmp/qbt.tar.gz -L \
-    "https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${QBT_VERSION}/qbittorrent-cli_$(echo $QBT_VERSION | cut -c2-)_linux_arm64.tar.gz" && \
-  tar xzf \
-    /tmp/qbt.tar.gz -C \
-    /tmp && \
-    mv /tmp/qbt /usr/bin && \
+  curl -L \
+    -o /usr/bin/qbt \
+    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt-arm64" && \
+  chmod +x /usr/bin/qbt && \
   echo "**** cleanup ****" && \
+  apk del --purge \
+    build-dependencies && \
   rm -rf \
+    /root/.cache \
     /tmp/*
 
 # add local files

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -49,10 +49,13 @@ RUN \
   apk add -U --upgrade --no-cache \
     qbittorrent-nox==${QBITTORRENT_VERSION} && \
   echo "***** install qbitorrent-cli ****" && \
+  mkdir /qbt && \
   curl -L \
-    -o /usr/bin/qbt \
-    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt-arm64" && \
-  chmod +x /usr/bin/qbt && \
+    -o /tmp/qbt.tar.gz \
+    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt-arm64.tar.gz" && \
+  tar xf \
+    /tmp/qbt.tar.gz -C \
+    /qbt && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -51,10 +51,13 @@ RUN \
   apk add -U --upgrade --no-cache \
     qbittorrent-nox==${QBITTORRENT_VERSION} && \
   echo "***** install qbitorrent-cli ****" && \
+  mkdir /qbt && \
   curl -L \
-    -o /usr/bin/qbt \
-    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt-arm" && \
-  chmod +x /usr/bin/qbt && \
+    -o /tmp/qbt.tar.gz \
+    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt-arm.tar.gz" && \
+  tar xf \
+    /tmp/qbt.tar.gz -C \
+    /qbt && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -9,36 +9,57 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thespad"
 
 # environment settings
+ARG QBT_VERSION=1.7
+ARG UNRAR_VERSION=6.1.4
 ENV HOME="/config" \
 XDG_CONFIG_HOME="/config" \
 XDG_DATA_HOME="/config"
 
 # install runtime packages and qbitorrent-cli
 RUN \
+  echo "**** install build packages ****" && \
+  apk add --no-cache --upgrade --virtual=build-dependencies \
+    make \
+    g++ \
+    gcc && \
+  echo "**** install packages ****" && \
   apk add -U --update --no-cache \
     bash \
     curl \
+    gcompat \
+    icu-libs \
+    libc6-compat \
+    libstdc++ \
+    openssl \
+    p7zip \
     python3 && \
+  echo "**** install unrar from source ****" && \
+  mkdir /tmp/unrar && \
+  curl -o \
+    /tmp/unrar.tar.gz -L \
+    "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/unrar.tar.gz -C \
+    /tmp/unrar --strip-components=1 && \
+  cd /tmp/unrar && \
+  make && \
+  install -v -m755 unrar /usr/bin && \
   if [ -z ${QBITTORRENT_VERSION+x} ]; then \
-    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/armhf/APKINDEX.tar.gz" | tar -xz -C /tmp \
+    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
     && awk '/^P:qbittorrent-nox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
   fi && \
   apk add -U --upgrade --no-cache \
     qbittorrent-nox==${QBITTORRENT_VERSION} && \
   echo "***** install qbitorrent-cli ****" && \
-  if [ -z ${QBT_VERSION+x} ]; then \
-    QBT_VERSION=$(curl -sX GET "https://api.github.com/repos/ludviglundgren/qbittorrent-cli/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
-  fi && \
-  curl -o \
-    /tmp/qbt.tar.gz -L \
-    "https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${QBT_VERSION}/qbittorrent-cli_$(echo $QBT_VERSION | cut -c2-)_linux_armv6.tar.gz" && \
-  tar xzf \
-    /tmp/qbt.tar.gz -C \
-    /tmp && \
-    mv /tmp/qbt /usr/bin && \
+  curl -L \
+    -o /usr/bin/qbt \
+    "https://github.com/linuxserver/docker-qbittorrent/releases/download/qbt-${QBT_VERSION}/qbt-arm" && \
+  chmod +x /usr/bin/qbt && \
   echo "**** cleanup ****" && \
+  apk del --purge \
+    build-dependencies && \
   rm -rf \
+    /root/.cache \
     /tmp/*
 
 # add local files

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **02.03.22:** - Add unrar, 7zip, and qbitorrent-cli.
 * **01.03.22:** - Add python for search plugin support.
 * **23.02.22:** - Rebase to Alpine Edge, install from Alpine repos.
 * **19.02.22:** - Add jq to build-stage

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -69,6 +69,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "02.03.22:", desc: "Add unrar, 7zip, and qbitorrent-cli." }
   - { date: "01.03.22:", desc: "Add python for search plugin support." }
   - { date: "23.02.22:", desc: "Rebase to Alpine Edge, install from Alpine repos." }
   - { date: "19.02.22:", desc: "Add jq to build-stage" }

--- a/root/usr/bin/qbt
+++ b/root/usr/bin/qbt
@@ -1,0 +1,14 @@
+#!/usr/bin/with-contenv bash
+
+# qbt bash wrapper to prompt user when trying to save password
+if [[ "$@" == "settings set password" ]]; then
+  echo "Setting password is not supported"
+  echo "Please use --ask-for-password or --password"
+elif [[ "$@" == "settings set"* ]]; then
+  /qbt/qbt "$@"
+elif [[ "$@" != *"--ask-for-password"* ]] && [[ "$@" != *"--password"* ]];then
+  echo "Please use --ask-for-password or --password and ensure username/url are set"
+  /qbt/qbt "$@"
+else
+  /qbt/qbt "$@"
+fi


### PR DESCRIPTION
closes #151
closes #161

I stashed musl bins for qbt in the releases, qbt arm is flaky does not work on qemu arm64/x64 work fine. 
https://github.com/linuxserver/docker-qbittorrent/releases/tag/qbt-1.7

We can potentially setup a github action on a dedicated repo for building these bins down the line if needed. 
