### PR TITLE
Fix qbittorrent-cli url causing failure when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN \
       | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   curl -o \
     /tmp/qbt.tar.gz -L \
-    "https://github.com/fedarovich/qbittorrent-cli/releases/download/${QBT_VERSION}/qbt-linux-alpine-x64-${QBT_VERSION:1}.tar.gz" && \
+    "https://github.com/fedarovich/qbittorrent-cli/releases/download/${QBT_VERSION}/qbt-linux-alpine-x64-${QBT_VERSION//[a-zA-Z\-]/}.tar.gz" && \
   tar xf \
     /tmp/qbt.tar.gz -C \
     /qbt && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -43,7 +43,7 @@ RUN \
       | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   curl -o \
     /tmp/qbt.tar.gz -L \
-    "https://github.com/fedarovich/qbittorrent-cli/releases/download/${QBT_VERSION}/qbt-linux-alpine-arm64-${QBT_VERSION:1}.tar.gz" && \
+    "https://github.com/fedarovich/qbittorrent-cli/releases/download/${QBT_VERSION}/qbt-linux-alpine-arm64-${QBT_VERSION//[a-zA-Z\-]/}.tar.gz" && \
   tar xf \
     /tmp/qbt.tar.gz -C \
     /qbt && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-qbittorrent/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

The [most recent releases](https://github.com/fedarovich/qbittorrent-cli/releases) of `qbittorrent-cli` (as of today 2023-12-19) are nightly builds and have a slightly different download url, which is causing the docker build process to try and download from a broken url, resulting in build failure. This is also causing the latest builds to [fail](https://ci.linuxserver.io/blue/organizations/jenkins/Docker-Pipeline-Builders%2Fdocker-qbittorrent/detail/master/829/pipeline).

Using the latest example, it's trying to download `qbittorrent-cli` from:

`https://github.com/fedarovich/qbittorrent-cli/releases/download/nightly-v1.8.23349.1/qbt-linux-alpine-x64-ightly-v1.8.23349.1.tar.gz`

but the correct url is: 

`https://github.com/fedarovich/qbittorrent-cli/releases/download/nightly-v1.8.23349.1/qbt-linux-alpine-x64-1.8.23349.1.tar.gz`

My change removes all `[a-zA-Z]` and `-` characters in the second cli version string so that the resulting URL is correct.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

It makes the docker file download qbittorrent-cli from the correct URL and stops the build from failing



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally by modifying the failing dockerfile and re-running it which results in a successful build

**NOTE:** This only fixes the broken url. There is also the question of should this build be using the nightly version of qbittorrent-cli - but thats a question for the maintainers

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
