### PR TITLE
Add torrenting port configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Due to issues with CSRF and port mapping, should you require to alter the port f
 
 For example, to set the port to 8090 you need to set -p 8090:8090 and -e WEBUI_PORT=8090
 
+### TORRENTING_PORT
+
+A bittorrent client can be an active or a passive node. Running your client as an active node has the advantage of being able to connect to both active and passive peers, and can potentially increase the number of incoming connections. This requires an open port on the host machine which might differ from container's internal one.
+
+Similarly to the WEBUI_PORT, to set the port to 6887 you need to pass -p 6887:6887, -p 6887:6887/udp and -e TORRENTING_PORT=6887 arguments to Docker.
+
 ## Usage
 
 To help you get started creating a container from this image you can either use docker-compose or the docker cli.
@@ -97,6 +103,7 @@ services:
       - PGID=1000
       - TZ=Etc/UTC
       - WEBUI_PORT=8080
+      - TORRENTING_PORT=6881
     volumes:
       - /path/to/appdata/config:/config
       - /path/to/downloads:/downloads
@@ -116,6 +123,7 @@ docker run -d \
   -e PGID=1000 \
   -e TZ=Etc/UTC \
   -e WEBUI_PORT=8080 \
+  -e TORRENTING_PORT=6881 \
   -p 8080:8080 \
   -p 6881:6881 \
   -p 6881:6881/udp \
@@ -138,6 +146,7 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
 | `-e WEBUI_PORT=8080` | for changing the port of the web UI, see below for explanation |
+| `-e TORRENTING_PORT=6881` | for changing the port of tcp/udp connection, see below for explanation |
 | `-v /config` | Contains all relevant configuration files. |
 | `-v /downloads` | Location of downloads on disk. |
 
@@ -302,6 +311,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **10.02.24:** - Add torrenting port support.
 * **31.01.24:** - Remove obsolete compat packages.
 * **25.12.23:** - Only pull stable releases of qbittorrent-cli.
 * **07.10.23:** - Install unrar from [linuxserver repo](https://github.com/linuxserver/docker-unrar).

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -33,6 +33,7 @@ param_ports:
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "WEBUI_PORT", env_value: "8080", desc: "for changing the port of the web UI, see below for explanation"}
+  - { env_var: "TORRENTING_PORT", env_value: "6881", desc: "for changing the port of tcp/udp connection, see below for explanation" }
 
 # application setup block
 app_setup_block_enabled: true
@@ -49,8 +50,15 @@ app_setup_block: |
 
   For example, to set the port to 8090 you need to set -p 8090:8090 and -e WEBUI_PORT=8090
 
+  ### TORRENTING_PORT
+
+  A bittorrent client can be an active or a passive node. Running your client as an active node has the advantage of being able to connect to both active and passive peers, and can potentially increase the number of incoming connections. This requires an open port on the host machine which might differ from container's internal one.
+
+  Similarly to the WEBUI_PORT, to set the port to 6887 you need to pass -p 6887:6887, -p 6887:6887/udp and -e TORRENTING_PORT=6887 arguments to Docker.
+
 # changelog
 changelogs:
+  - { date: "10.02.24:", desc: "Add torrenting port support." }
   - { date: "31.01.24:", desc: "Remove obsolete compat packages."}
   - { date: "25.12.23:", desc: "Only pull stable releases of qbittorrent-cli."}
   - { date: "07.10.23:", desc: "Install unrar from [linuxserver repo](https://github.com/linuxserver/docker-unrar)."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -2,7 +2,8 @@
 # shellcheck shell=bash
 
 WEBUI_PORT=${WEBUI_PORT:-8080}
+TORRENTING_PORT=${TORRENTING_PORT:-6881}
 
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \
-        s6-setuidgid abc /usr/bin/qbittorrent-nox --webui-port="${WEBUI_PORT}"
+        s6-setuidgid abc /usr/bin/qbittorrent-nox --webui-port="${WEBUI_PORT}" --torrenting-port="${TORRENTING_PORT}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-qbittorrent/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Adds `TORRENTING_PORT` environment variable for easy qBittorrent port change.

## Benefits of this PR and context:
The torrenting port is can override qBittorrent's setting without changing the configuration. This increases the portability of the container and adds more granular control over its behaviour.

## How Has This Been Tested?
1. I built the container using the command provided in the [Contribution guide](https://github.com/linuxserver/docker-qbittorrent/blob/master/.github/CONTRIBUTING.md#testing-your-changes)
2. Then I set the `image` in an existing docker-compose.yml to point the newly created image:    
    ```diff
       qbittorrent:
    -     image: lscr.io/linuxserver/qbittorrent:latest
    +     image: linuxserver/qbittorrent
         hostname: qbittorrent
         volumes:
           - /media/downloads:/downloads
         ports:
           - 6887:6887
           - 6887:6887/udp
         environment:
           TORRENTING_PORT: 6887
    ```
3. Then (I waited a bit, and) I started the container and ran `docker compose ps --format 'table {{.Service}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'` for checking the status:    
    ```bash
    $ docker compose  ps --format 'table {{.Service}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'
    SERVICE       IMAGE                     STATUS                   PORTS
    qbittorrent   linuxserver/qbittorrent   Up 9 minutes (healthy)   6881/tcp, 8080/tcp, 6881/udp, 0.0.0.0:6887->6887/tcp, 0.0.0.0:6887->6887/udp, :::6887->6887/tcp, :::6887->6887/udp
    ```
4. Then I also _logged in_ via `docker compose exec qbittorrent sh` and checked the running command:
    ```bash
    root@qbittorrent:/# ps aux | grep abc
    abc          216  2.8  0.0  73636 55696 ?        Ssl  11:16   0:05 /usr/bin/qbittorrent-nox --webui-port=8080 --torrenting-port=6887
    root         399  0.0  0.0   1612     4 pts/0    S+   11:19   0:00 grep abc
    ```
5. Finally, I checked if the client's connection is active on a tracker.

## Source / References:
Relates to the stale #227 pull request.
