### PR TITLE
change ingestion point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,20 @@ XDG_DATA_HOME="/config"
 # install runtime packages and qbitorrent-cli
 RUN \
   echo "**** install packages ****" && \
-  apk add --no-cache \
+  apk add -U --update --no-cache \
     grep \
     icu-libs \
     p7zip \
     python3 \
     qt6-qtbase-sqlite && \
   if [ -z ${QBITTORRENT_VERSION+x} ]; then \
-    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
-    && awk '/^P:qbittorrent-nox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
+     QBITTORRENT_VERSION=$(curl -sL "https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases" | \
+     jq -r 'first(.[] | select(.prerelease == false) | .tag_name)'); \
   fi && \
-  apk add -U --upgrade --no-cache \
-    qbittorrent-nox==${QBITTORRENT_VERSION} && \
+  curl -o \
+    /app/qbittorrent-nox -L \
+    "https://github.com/userdocs/qbittorrent-nox-static/releases/download/${QBITTORRENT_VERSION}/x86_64-qbittorrent-nox" && \
+  chmod +x /app/qbittorrent-nox && \
   echo "***** install qbitorrent-cli ****" && \
   mkdir /qbt && \
   if [ -z ${QBT_CLI_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -20,18 +20,20 @@ XDG_DATA_HOME="/config"
 # install runtime packages and qbitorrent-cli
 RUN \
   echo "**** install packages ****" && \
-  apk add --no-cache \
+  apk add -U --update --no-cache \
     grep \
     icu-libs \
     p7zip \
     python3 \
     qt6-qtbase-sqlite && \
   if [ -z ${QBITTORRENT_VERSION+x} ]; then \
-    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
-    && awk '/^P:qbittorrent-nox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
+     QBITTORRENT_VERSION=$(curl -sL "https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases" | \
+     jq -r 'first(.[] | select(.prerelease == true) | .tag_name)'); \
   fi && \
-  apk add -U --upgrade --no-cache \
-    qbittorrent-nox==${QBITTORRENT_VERSION} && \
+  curl -o \
+    /app/qbittorrent-nox -L \
+    "https://github.com/userdocs/qbittorrent-nox-static/releases/download/${QBITTORRENT_VERSION}/aarch64-qbittorrent-nox" && \
+  chmod +x /app/qbittorrent-nox && \
   echo "***** install qbitorrent-cli ****" && \
   mkdir /qbt && \
   if [ -z ${QBT_CLI_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -28,7 +28,7 @@ RUN \
     qt6-qtbase-sqlite && \
   if [ -z ${QBITTORRENT_VERSION+x} ]; then \
      QBITTORRENT_VERSION=$(curl -sL "https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases" | \
-     jq -r 'first(.[] | select(.prerelease == true) | .tag_name)'); \
+     jq -r 'first(.[] | select(.prerelease == false) | .tag_name)'); \
   fi && \
   curl -o \
     /app/qbittorrent-nox -L \

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-qbittorrent
 external_type: na
-custom_version_command: "curl -sL 'https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases' | jq -r 'first(.[] | select(.prerelease == true) | .tag_name)'"
+custom_version_command: "curl -sL 'https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases' | jq -r 'first(.[] | select(.prerelease == false) | .tag_name)'"
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-qbittorrent
-external_type: alpine_repo
+external_type: na
+custom_version_command: "curl -sL 'https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases' | jq -r 'first(.[] | select(.prerelease == true) | .tag_name)'"
 release_type: stable
 release_tag: latest
 ls_branch: master
@@ -17,7 +18,6 @@ repo_vars:
   - DIST_IMAGE = 'alpine'
   - DIST_TAG = 'edge'
   - DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/edge/community/'
-  - DIST_REPO_PACKAGES = 'qbittorrent-nox'
   - MULTIARCH='true'
   - CI='true'
   - CI_WEB='true'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -62,6 +62,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "01.11.24:", desc: "Ingest qbittorrent from github rather than Alpine repo." }
   - { date: "17.07.24:", desc: "Restore qbittorrent-cli as it now supports openssl 3." }
   - { date: "25.05.24:", desc: "Remove qbittorrent-cli as it still requires openssl 1.1 which is EOL." }
   - { date: "14.02.24:", desc: "Only set/override torrenting port if the optional env var is set." }

--- a/root/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -13,4 +13,4 @@ fi
 
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z ${WEBUI_ADDRESS} ${WEBUI_PORT}" \
-        s6-setuidgid abc /usr/bin/qbittorrent-nox --webui-port="${WEBUI_PORT}" ${TORRENTING_PORT_ARG}
+        s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" ${TORRENTING_PORT_ARG}


### PR DESCRIPTION
a bunch of kids are losing their shit over the rce that has existed forever, while there is no reason to panic, i dont want to listen to their whining, so we can do this, or leave the PR build up and they can use this tag to get libtorrentv2 on 5.0.1 for now.

we can also just create a whole new branch, dependent on this random guy rather than alpine as a temporary stop gap