### PR TITLE
Add missing `exec` to non-root branch of svc-qbittorrent s6 run script

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -11,6 +11,7 @@ exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z ${WEBUI_ADDRESS} ${WEBUI_PORT:-8080}" \
         s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT:-8080}" ${TORRENTING_PORT+--torrenting-port=${TORRENTING_PORT}}
 else
+exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z ${WEBUI_ADDRESS} ${WEBUI_PORT:-8080}" \
         /app/qbittorrent-nox --webui-port="${WEBUI_PORT:-8080}" ${TORRENTING_PORT+--torrenting-port=${TORRENTING_PORT}}
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-qbittorrent/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Add the missing `exec` keyword to the non-root branch of the svc-qbittorrent s6 run script. Without it, bash spawns `s6-notifyoncheck -d ...` as a child; the `-d` flag causes s6-notifyoncheck to daemonize, the bash script exits, and the s6-rc supervisor tears down the service group — SIGTERMing the orphaned qBittorrent process within ~1s of every start.

The root branch has used `exec` since [c828bd5c](https://github.com/linuxserver/docker-qbittorrent/commit/c828bd5c) (2022-09-20, "Exec notify"). The else branch was added in [016be7b8](https://github.com/linuxserver/docker-qbittorrent/commit/016be7b8) (2024-12-20, "Support nonroot operation") without the matching `exec`. The bug was latent for ~17 months, likely made deterministic by [5152b908](https://github.com/linuxserver/docker-qbittorrent/commit/5152b908) (2026-05-04, "Switch to static builds for v2") which changed startup timing.

Closes #435

## Benefits of this PR and context:

Restores non-root operation (k8s `securityContext.runAsUser`, Podman rootless, any environment that sets `LSIO_NON_ROOT_USER`). Currently-affected users have to pin to `5.1.4-r2-ls443` or earlier.

Distinct from #430 / #432 / #433 / #434 (upstream qBittorrent lockfile race, resolved by deleting the lockfile) — those reports describe "WebUI not accessible" or "container hangs" without exit signal. This bug terminates the container with exit 137 within ~1s and tight-loops.

## How Has This Been Tested?

Root-cause established by static analysis:

1. Read current `root/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run` on `master` — confirmed asymmetric `exec` (root branch has it, else branch doesn't).
2. Traced introduction to `016be7b8` via `git log -- root/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run` — the else branch was added without the matching `exec`.

Triggering symptom observed in production: `qBittorrent termination initiated` log line within ~1s of startup, exit 137, tight pod restart loop on `5.2.0_v2.0.12-ls455` in a k8s cluster with `securityContext.runAsUser` set to a non-zero UID. Workaround currently in place is pinning to `5.1.4-r2-ls443`.

End-to-end validation of the patch (build the fixed image, deploy to the affected k8s cluster, watch a non-root pod run cleanly) has not yet been performed — submitting on the strength of the static analysis since the asymmetry is unambiguous and the fix is the minimal change to restore symmetry with the working root branch. Happy to test against a CI build of the patched branch if that's preferred before merge.

## Source / References:

- Asymmetric introduction: https://github.com/linuxserver/docker-qbittorrent/commit/016be7b8
- Likely race-exposing commit: https://github.com/linuxserver/docker-qbittorrent/commit/5152b908
- Original `exec notify` on root branch: https://github.com/linuxserver/docker-qbittorrent/commit/c828bd5c
- Related (but distinct, lockfile-race) issues: #430, #432, #433, #434
