### PR TITLE
feat: set WebUI password via WEBUI_PASSWORD env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ A bittorrent client can be an active or a passive node. Running your client as a
 
 Similarly to the WEBUI_PORT, to set the port to 6887 you need to pass -p 6887:6887, -p 6887:6887/udp and -e TORRENTING_PORT=6887 arguments to Docker.
 
+### WEBUI_PASSWORD variable
+
+You can set a persistent WebUI password at container startup by passing `-e WEBUI_PASSWORD=yourpassword`. This will configure the `admin` user's password on every container start, overriding both the auto-generated temporary password and any password previously set via the web UI.
+
+If `WEBUI_PASSWORD` is not set, the default qBittorrent behaviour applies: a temporary password is printed to the container log on each startup until you set a password through the web UI.
+
 ## Read-Only Operation
 
 This image can be run with a read-only container filesystem. For details please [read the docs](https://docs.linuxserver.io/misc/read-only/).
@@ -157,6 +163,7 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
 | `-e WEBUI_PORT=8080` | for changing the port of the web UI, see below for explanation |
 | `-e TORRENTING_PORT=6881` | for changing the port of tcp/udp connection, see below for explanation |
+| `-e WEBUI_PASSWORD=` | set a persistent WebUI password for the admin user at startup (optional) |
 | `-v /config` | Contains all relevant configuration files. |
 | `-v /downloads` | Location of downloads on disk. |
 | `--stop-timeout=` | If you have a large number of torrents you may need to increase the container stop timeout to ensure a clean shutdown. |

--- a/README.md
+++ b/README.md
@@ -83,15 +83,6 @@ A bittorrent client can be an active or a passive node. Running your client as a
 
 Similarly to the WEBUI_PORT, to set the port to 6887 you need to pass -p 6887:6887, -p 6887:6887/udp and -e TORRENTING_PORT=6887 arguments to Docker.
 
-### WEBUI_PASSWORD variable
-
-You can set a persistent WebUI password at container startup by passing `-e WEBUI_PASSWORD=yourpassword`. This will configure the `admin` user's password on every container start, overriding both the auto-generated temporary password and any password previously set via the web UI.
-
-If `WEBUI_PASSWORD` is not set, the default qBittorrent behaviour applies: a temporary password is printed to the container log on each startup until you set a password through the web UI.
-
->[!NOTE]
->Like all Docker environment variables, `WEBUI_PASSWORD` is visible to anyone with access to the container's configuration (e.g. via `docker inspect`). For sensitive deployments, use Docker secrets with the `FILE__WEBUI_PASSWORD` mechanism described below.
-
 ## Read-Only Operation
 
 This image can be run with a read-only container filesystem. For details please [read the docs](https://docs.linuxserver.io/misc/read-only/).
@@ -166,7 +157,6 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
 | `-e WEBUI_PORT=8080` | for changing the port of the web UI, see below for explanation |
 | `-e TORRENTING_PORT=6881` | for changing the port of tcp/udp connection, see below for explanation |
-| `-e WEBUI_PASSWORD=` | set a persistent WebUI password for the admin user at startup (optional) |
 | `-v /config` | Contains all relevant configuration files. |
 | `-v /downloads` | Location of downloads on disk. |
 | `--stop-timeout=` | If you have a large number of torrents you may need to increase the container stop timeout to ensure a clean shutdown. |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ You can set a persistent WebUI password at container startup by passing `-e WEBU
 
 If `WEBUI_PASSWORD` is not set, the default qBittorrent behaviour applies: a temporary password is printed to the container log on each startup until you set a password through the web UI.
 
+>[!NOTE]
+>Like all Docker environment variables, `WEBUI_PASSWORD` is visible to anyone with access to the container's configuration (e.g. via `docker inspect`). For sensitive deployments, use Docker secrets with the `FILE__WEBUI_PASSWORD` mechanism described below.
+
 ## Read-Only Operation
 
 This image can be run with a read-only container filesystem. For details please [read the docs](https://docs.linuxserver.io/misc/read-only/).

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -31,6 +31,8 @@ param_usage_include_env: true
 param_env_vars:
   - {env_var: "WEBUI_PORT", env_value: "8080", desc: "for changing the port of the web UI, see below for explanation"}
   - {env_var: "TORRENTING_PORT", env_value: "6881", desc: "for changing the port of tcp/udp connection, see below for explanation"}
+opt_param_env_vars:
+  - {env_var: "WEBUI_PASSWORD", env_value: "yourpassword", desc: "set a persistent WebUI password for the admin user at startup"}
 opt_param_usage_include_vols: true
 opt_param_volumes:
   - {vol_path: "/downloads", vol_host_path: "/path/to/downloads", desc: "Location of downloads on disk."}
@@ -58,6 +60,15 @@ app_setup_block: |
   A bittorrent client can be an active or a passive node. Running your client as an active node has the advantage of being able to connect to both active and passive peers, and can potentially increase the number of incoming connections. This requires an open port on the host machine which might differ from container's internal one.
 
   Similarly to the WEBUI_PORT, to set the port to 6887 you need to pass -p 6887:6887, -p 6887:6887/udp and -e TORRENTING_PORT=6887 arguments to Docker.
+
+  ### WEBUI_PASSWORD variable
+
+  You can set a persistent WebUI password at container startup by passing `-e WEBUI_PASSWORD=yourpassword`. This will configure the `admin` user's password on every container start, overriding both the auto-generated temporary password and any password previously set via the web UI.
+
+  If `WEBUI_PASSWORD` is not set, the default qBittorrent behaviour applies: a temporary password is printed to the container log on each startup until you set a password through the web UI.
+
+  >[!NOTE]
+  >Like all Docker environment variables, `WEBUI_PASSWORD` is visible to anyone with access to the container's configuration (e.g. via `docker inspect`). For sensitive deployments, use Docker secrets with the `FILE__WEBUI_PASSWORD` mechanism described below.
 # init diagram
 init_diagram: |
   "qbittorrent:latest": {

--- a/root/etc/s6-overlay/s6-rc.d/init-qbittorrent-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-qbittorrent-config/run
@@ -9,6 +9,22 @@ if [[ ! -f /config/qBittorrent/qBittorrent.conf ]]; then
     cp /defaults/qBittorrent.conf /config/qBittorrent/qBittorrent.conf
 fi
 
+# set WebUI password from environment variable if provided
+if [[ -n ${WEBUI_PASSWORD} ]]; then
+    HASH=$(python3 -c "
+import hashlib, os, base64, sys
+password = sys.argv[1].encode('utf-8')
+salt = os.urandom(16)
+dk = hashlib.pbkdf2_hmac('sha512', password, salt, 100000)
+print('@ByteArray(' + base64.b64encode(salt).decode() + ':' + base64.b64encode(dk).decode() + ')', end='')
+" "${WEBUI_PASSWORD}")
+    if grep -qF "WebUI\\Password_PBKDF2=" /config/qBittorrent/qBittorrent.conf; then
+        sed -i "s|^WebUI\\\\Password_PBKDF2=.*|WebUI\\\\Password_PBKDF2=${HASH}|" /config/qBittorrent/qBittorrent.conf
+    else
+        printf "WebUI\\\\Password_PBKDF2=%s\\n" "${HASH}" >> /config/qBittorrent/qBittorrent.conf
+    fi
+fi
+
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     # chown download directory if currently not set to abc
     if grep -qe ' /downloads ' /proc/mounts; then

--- a/root/etc/s6-overlay/s6-rc.d/init-qbittorrent-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-qbittorrent-config/run
@@ -11,17 +11,17 @@ fi
 
 # set WebUI password from environment variable if provided
 if [[ -n ${WEBUI_PASSWORD} ]]; then
-    HASH=$(python3 -c "
+    HASH=$(printf '%s' "${WEBUI_PASSWORD}" | python3 -c "
 import hashlib, os, base64, sys
-password = sys.argv[1].encode('utf-8')
+password = sys.stdin.read().encode('utf-8')
 salt = os.urandom(16)
 dk = hashlib.pbkdf2_hmac('sha512', password, salt, 100000)
 print('@ByteArray(' + base64.b64encode(salt).decode() + ':' + base64.b64encode(dk).decode() + ')', end='')
-" "${WEBUI_PASSWORD}")
-    if grep -qF "WebUI\\Password_PBKDF2=" /config/qBittorrent/qBittorrent.conf; then
+")
+    if grep -qF 'WebUI\Password_PBKDF2=' /config/qBittorrent/qBittorrent.conf; then
         sed -i "s|^WebUI\\\\Password_PBKDF2=.*|WebUI\\\\Password_PBKDF2=${HASH}|" /config/qBittorrent/qBittorrent.conf
     else
-        printf "WebUI\\\\Password_PBKDF2=%s\\n" "${HASH}" >> /config/qBittorrent/qBittorrent.conf
+        printf 'WebUI\\Password_PBKDF2=%s\n' "${HASH}" >> /config/qBittorrent/qBittorrent.conf
     fi
 fi
 


### PR DESCRIPTION
- [ x ] I have read the [contributing](https://github.com/linuxserver/docker-qbittorrent/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
feat: set WebUI password via WEBUI_PASSWORD env var

## Benefits of this PR and context:
qBittorrent generates a random temporary password on every startup unless one is configured, requiring manual intervention via the web UI. Add WEBUI_PASSWORD env var support to inject a persistent password at container start.

Changes

## How Has This Been Tested?
Build and start the container with a password in WEBUI_PASSWORD and use that password to login